### PR TITLE
Uso de puerto público 0.0.0.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,4 +56,4 @@ def get_result():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, host='0.0.0.0')


### PR DESCRIPTION
Uso de puerto público 0.0.0.0 en lugar de localhost por default.